### PR TITLE
move cookie whitelist and blacklist to XDG_DATA_DIR

### DIFF
--- a/lib/cookie_blocking.lua
+++ b/lib/cookie_blocking.lua
@@ -5,8 +5,8 @@
 
 require "cookies"
 
-cookies.whitelist_path = luakit.config_dir .. "/cookie.whitelist"
-cookies.blacklist_path = luakit.config_dir .. "/cookie.blacklist"
+cookies.whitelist_path = luakit.data_dir .. "/cookie.whitelist"
+cookies.blacklist_path = luakit.data_dir .. "/cookie.blacklist"
 
 local cache = {}
 


### PR DESCRIPTION
If backwards compatibilty is needed, just reject and I'll see if I can figure out how to fall back gracefully.

Storing this data outside of $XDG_CONFIG_DIR is better for those of us who share our dotfiles 
